### PR TITLE
Add Detailed Description MD Preview

### DIFF
--- a/view/frontend/layout/casestudy_customer_edit.xml
+++ b/view/frontend/layout/casestudy_customer_edit.xml
@@ -2,6 +2,9 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <update handle="customer_account"/>
+    <head>
+        <script src="https://cdn.jsdelivr.net/npm/showdown@2.1.0/dist/showdown.min.js" src_type="url"/>
+    </head>
     <body>
         <referenceContainer name="content">
             <block class="Qoliber\CaseStudyManager\Block\Customer\CaseStudy\Form"

--- a/view/frontend/templates/form.phtml
+++ b/view/frontend/templates/form.phtml
@@ -15,6 +15,29 @@ use Magento\Framework\Escaper;
 
 $caseStudy = $block->getCaseStudy();
 ?>
+<script>
+    document.addEventListener('DOMContentLoaded', function () {
+        // Initialize the Markdown editor
+        let contentField = document.getElementById('content');
+        let contentPreview = document.getElementById('content_preview');
+        if (contentField && contentPreview) {
+            updateContentPreview();
+            contentField.addEventListener('input', function () {
+                updateContentPreview();
+            });
+        }
+    });
+
+    function updateContentPreview() {
+        let text = document.getElementById('content').value,
+            target = document.getElementById('content_preview'),
+            converter = new showdown.Converter(),
+            html = converter.makeHtml(text);
+
+        target.innerHTML = html;
+    }
+</script>
+
 <form class="max-w-6xl mx-auto bg-white shadow-lg rounded-lg p-6"
       action="<?= $escaper->escapeUrl($block->getFormAction()) ?>"
       method="post"
@@ -110,19 +133,30 @@ $caseStudy = $block->getCaseStudy();
         </div>
 
         <div class="col-span-2">
-            <label for="content" class="block text-sm font-medium text-gray-600">
-                <?= $escaper->escapeHtml(__('Detailed Description')) ?>
-            </label>
-            <textarea name="content"
-                      id="content"
-                      rows="6"
-                      class="form-input w-full wysiwyg-editor"
-                      minlength="100"
-                      required><?= $escaper->escapeHtml($caseStudy->getContent()) ?></textarea>
-            <p class="mt-1 text-sm text-gray-500">
-                <?= $escaper->escapeHtml(__('Min 100 characters.')) ?></p>
-            <p class="mt-1 text-sm text-blue-600">
-                <?= $escaper->escapeHtml(__('Only Markdown formatting is allowed in this field.')) ?></p>
+            <div id="content_container" class="mb-4 flex flex-col flex-1 md:grid md:grid-cols-2 gap-4 items-stretch">
+                <div class="flex items-start flex-col">
+                    <label for="content" class="block text-sm font-medium text-gray-600">
+                        <?= $escaper->escapeHtml(__('Detailed Description')) ?>
+                    </label>
+                    <textarea name="content"
+                            id="content"
+                            rows="6"
+                            class="form-input w-full wysiwyg-editor"
+                            minlength="100"
+                            required><?= $escaper->escapeHtml($caseStudy->getContent()) ?></textarea>
+                    <p class="mt-1 text-sm text-gray-500">
+                        <?= $escaper->escapeHtml(__('Min 100 characters.')) ?></p>
+                    <p class="mt-1 text-sm text-blue-600">
+                        <?= $escaper->escapeHtml(__('Only Markdown formatting is allowed in this field.')) ?></p>
+                </div>
+                <div class="flex items-start flex-col">
+                    <label for="content_preview" class="block text-sm font-medium text-gray-600">
+                        <?= $escaper->escapeHtml(__('Preview')) ?>
+                    </label>
+                        <span id="content_preview" class="form-input w-full"></span>
+                </div>
+            </div>
+            
         </div>
 
         <div class="col-span-2">


### PR DESCRIPTION
* Add CDN script link to [showdownjs](https://github.com/showdownjs/showdown/) on casestudy/customer/edit page layout
* Add content_preview container for description
  * This required the field layout to be adjusted a little
  * Sits side-by-side on medium and greater viewports, layered on small viewports
* Add eventListener and function to update preview on edits to the content input field

Resolves #2 